### PR TITLE
refactor: simplify stripping of star characters

### DIFF
--- a/cleaning_utils/clear_stop_char.py
+++ b/cleaning_utils/clear_stop_char.py
@@ -231,7 +231,7 @@ def strip_stars(text: str) -> str:
         'hello to people'
 
     """
-    return text.strip("**").strip("*")
+    return text.strip("*")
 
 
 def removes_exceptions_from_list(


### PR DESCRIPTION
This PR replaces the redundant chained calls:

```python
text.strip("**").strip("*")
```

with:

```python
text.strip("*")
```

The argument to str.strip() is treated as a set of characters, so "**" behaves exactly like "*". The additional call does not change the result.

This change simplifies the implementation while preserving its existing behavior, including retaining star characters inside the text.

The issue was identified during an ongoing research project.

